### PR TITLE
fix running via docker + config bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,7 @@ RUN npm ci --only=production
 COPY ./src ./src
 # default mockin port
 EXPOSE 3333
+# docker + node means IP to be 0.0.0.0 but exposed on host as 127.0.0.1
 ENV IP=0.0.0.0
+ENV ISSUER=http://127.0.0.1:3333
 CMD ["npm", "start"]

--- a/src/openid-configuration.js
+++ b/src/openid-configuration.js
@@ -39,7 +39,6 @@ export default () => { return(JSON.stringify({
     "response_types_supported": VALID_RESPONSE_TYPE,
     "scopes_supported": VALID_IDENTITY_SCOPES,
     "claims_supported": [
-        [
             "sub",
             "iss",
             "aud",
@@ -47,7 +46,6 @@ export default () => { return(JSON.stringify({
             "iat",
             "jti",
             "nonce",
-        ],
         ...VALID_IDENTITY_CLAIMS
     ]
 }, null, 2))}


### PR DESCRIPTION
* `claims_supported` key had an extra array nesting
* running via docker had wrong issuer