### PR TITLE
chore: bump GitHub Actions to Node-24-compatible majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: 'npm'
@@ -36,8 +36,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           # Node 24 ships npm 11.x natively, which is what OIDC trusted
           # publishing needs. Avoids `npm install -g npm@latest` — the
@@ -56,11 +56,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: sigstore/cosign-installer@v3
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
           TAG="${{ github.event.release.tag_name }}"
           VERSION="${TAG#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         id: build
         with:
           context: .


### PR DESCRIPTION
GitHub forces JS actions to Node 24 on 2026-06-16 and removes Node 20 on 2026-09-16. This bumps all Node-20 (or older) pinned actions to their latest Node-24-compatible majors.

Bumps:
- actions/checkout v4 -> v6
- actions/setup-node v4 -> v6
- docker/setup-qemu-action v3 -> v4 (was node20)
- docker/setup-buildx-action v3 -> v4 (was node20)
- docker/login-action v3 -> v4 (was node20)
- docker/build-push-action v6 -> v7 (was node20)

Left alone:
- sigstore/cosign-installer@v3 — composite action, not a JS/Node action.

No artifact actions in use. setup-node has explicit node-version, so the major bump is safe. actionlint passes on both workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
